### PR TITLE
Add Tariff cost increase

### DIFF
--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -20,9 +20,17 @@ import { Echophagist } from './monsters/act1_segment1/Echophage';
 import { FrenchCrow } from './monsters/act1_segment1/Marshflutter';
 import { VeilCapacitor } from './monsters/act1_segment1/ObeliskOfPentacles';
 import { VesperOfMeat } from './monsters/act1_segment1/VesperOfMeat';
+import { BrimstoneMudskipper } from './monsters/act1_segment1/BrimstoneMudskipper';
+import { SootLungHeron } from './monsters/act1_segment1/SootLungHeron';
+import { DisgruntledFerryman } from './monsters/act1_segment1/DisgruntledFerryman';
+import { TelegraphEel } from './monsters/act1_segment1/TelegraphEel';
+import { BogLampreyOUS } from './monsters/act1_segment1/BogLampreyOUS';
 import { EldritchMime } from './monsters/act1_segment2/FrenchMime';
 import { AccursedObelisk } from './monsters/act1_segment2/ObeliskOfCups';
 import { RuminantOfSwords } from './monsters/act1_segment2/RuminantOfSwords';
+import { RaftPirate } from './monsters/act1_segment2/RaftPirate';
+import { TollCollectorGoneMad } from './monsters/act1_segment2/TollCollectorGoneMad';
+import { RunoffElemental } from './monsters/act1_segment2/RunoffElemental';
 import { LuridAutarch } from './monsters/act2_boss/LuridAutarch';
 import { BureaucraticBehemoth } from './monsters/act2_segment1/BureaucraticBehemoth';
 import { CrawlingInfestation } from './monsters/act2_segment1/CrawlingInfestation';
@@ -105,6 +113,18 @@ export class ActSegment {
         },
         {
             enemies: [new SorrowmothSwarm(), new SorrowmothSwarm()]
+        },
+        {
+            enemies: [new BrimstoneMudskipper(), new SootLungHeron()]
+        },
+        {
+            enemies: [new DisgruntledFerryman(), new DisgruntledFerryman()]
+        },
+        {
+            enemies: [new TelegraphEel()]
+        },
+        {
+            enemies: [new BogLampreyOUS()]
         }
     ]);
 
@@ -117,6 +137,15 @@ export class ActSegment {
         },
         {
             enemies: [new AccursedObelisk()]
+        },
+        {
+            enemies: [new RaftPirate(), new RaftPirate()]
+        },
+        {
+            enemies: [new TollCollectorGoneMad()]
+        },
+        {
+            enemies: [new RunoffElemental()]
         }
     ]);
 

--- a/src/encounters/monsters/act1_segment1/BogLampreyOUS.ts
+++ b/src/encounters/monsters/act1_segment1/BogLampreyOUS.ts
@@ -1,0 +1,22 @@
+import { AbstractIntent, AttackIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { LeechingBite } from '../../../gamecharacters/buffs/enemy_buffs/LeechingBite';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class BogLampreyOUS extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Bog Lamprey O.U.S.',
+            portraitName: 'Horror Worm',
+            maxHitpoints: 35,
+            description: 'Parasitic horror gorged on spiritual essence.'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new LeechingBite(3));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        return [new AttackIntent({ baseDamage: 7, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Gnaw')];
+    }
+}

--- a/src/encounters/monsters/act1_segment1/BrimstoneMudskipper.ts
+++ b/src/encounters/monsters/act1_segment1/BrimstoneMudskipper.ts
@@ -1,0 +1,24 @@
+import { AbstractIntent, AttackIntent, ApplyDebuffToRandomCharacterIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { Poisoned } from '../../../gamecharacters/buffs/standard/Poisoned';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class BrimstoneMudskipper extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Brimstone Mudskipper',
+            portraitName: 'Salamander',
+            maxHitpoints: 20,
+            description: 'Once harmless amphibians bloated with pollution.'
+        });
+        this.size = CardSize.LARGE;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        if (Math.random() < 0.5) {
+            return [new AttackIntent({ baseDamage: 6, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Toxic Leap')];
+        }
+        return [new ApplyDebuffToRandomCharacterIntent({ debuff: new Poisoned(2), owner: this }).withTitle('Polluted Slick')];
+    }
+}

--- a/src/encounters/monsters/act1_segment1/DisgruntledFerryman.ts
+++ b/src/encounters/monsters/act1_segment1/DisgruntledFerryman.ts
@@ -1,0 +1,23 @@
+import { AbstractIntent, AttackIntent, BlockForSelfIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { CardSize } from '../../../gamecharacters/Primitives';
+
+export class DisgruntledFerryman extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Disgruntled Ferryman',
+            portraitName: 'Drowned Sailor',
+            maxHitpoints: 25,
+            description: 'Waterlogged demon muttering about fares.'
+        });
+        this.size = CardSize.LARGE;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new BlockForSelfIntent({ blockAmount: 10, owner: this }).withTitle('Old Routines')],
+            [new AttackIntent({ baseDamage: 7, owner: this }).withTitle('Oar Smash')]
+        ];
+        return IntentListCreator.selectRandomIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act1_segment1/SootLungHeron.ts
+++ b/src/encounters/monsters/act1_segment1/SootLungHeron.ts
@@ -1,0 +1,24 @@
+import { AbstractIntent, AttackIntent, ApplyDebuffToRandomCharacterIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { Blind } from '../../../gamecharacters/buffs/standard/Blind';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class SootLungHeron extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Soot-Lung Heron',
+            portraitName: 'Corrupted Bird',
+            maxHitpoints: 18,
+            description: 'Wading bird coughing clouds of smog.'
+        });
+        this.size = CardSize.LARGE;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        if (Math.random() < 0.5) {
+            return [new AttackIntent({ baseDamage: 5, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Tar Peck')];
+        }
+        return [new ApplyDebuffToRandomCharacterIntent({ debuff: new Blind(1), owner: this }).withTitle('Smog Cloud')];
+    }
+}

--- a/src/encounters/monsters/act1_segment1/TelegraphEel.ts
+++ b/src/encounters/monsters/act1_segment1/TelegraphEel.ts
@@ -1,0 +1,22 @@
+import { AbstractIntent, AttackIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { SignalInterference } from '../../../gamecharacters/buffs/enemy_buffs/SignalInterference';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class TelegraphEel extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Telegraph Eel',
+            portraitName: 'Electric Eel',
+            maxHitpoints: 30,
+            description: 'Cables fused with eels spark with stolen messages.'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new SignalInterference(2));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        return [new AttackIntent({ baseDamage: 8, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Shock Bite')];
+    }
+}

--- a/src/encounters/monsters/act1_segment2/RaftPirate.ts
+++ b/src/encounters/monsters/act1_segment2/RaftPirate.ts
@@ -1,0 +1,24 @@
+import { AbstractIntent, AttackIntent, ApplyBuffToSelfIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { Lethality } from '../../../gamecharacters/buffs/standard/Lethality';
+import { CardSize } from '../../../gamecharacters/Primitives';
+
+export class RaftPirate extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Raft Pirate',
+            portraitName: 'Pirate',
+            maxHitpoints: 22,
+            description: 'Opportunist with rusty harpoons.'
+        });
+        this.size = CardSize.LARGE;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new AttackIntent({ baseDamage: 6, owner: this }).withTitle('Harpoon')],
+            [new ApplyBuffToSelfIntent({ buff: new Lethality(2), owner: this }).withTitle('Plunder')]
+        ];
+        return IntentListCreator.selectRandomIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act1_segment2/RunoffElemental.ts
+++ b/src/encounters/monsters/act1_segment2/RunoffElemental.ts
@@ -1,0 +1,27 @@
+import { AbstractIntent, AttackIntent, ApplyDebuffToRandomCharacterIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { ToxicRetaliation } from '../../../gamecharacters/buffs/enemy_buffs/ToxicRetaliation';
+import { Poisoned } from '../../../gamecharacters/buffs/standard/Poisoned';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class RunoffElemental extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Runoff Elemental',
+            portraitName: 'Ooze',
+            maxHitpoints: 40,
+            description: 'Sentient pollution mixed with Styx water.'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new ToxicRetaliation(2));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new AttackIntent({ baseDamage: 8, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Corrosive Slam')],
+            [new ApplyDebuffToRandomCharacterIntent({ debuff: new Poisoned(3), owner: this }).withTitle('Toxic Wave')]
+        ];
+        return IntentListCreator.selectRandomIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act1_segment2/TollCollectorGoneMad.ts
+++ b/src/encounters/monsters/act1_segment2/TollCollectorGoneMad.ts
@@ -1,0 +1,22 @@
+import { AbstractIntent, AttackIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { TariffAura } from '../../../gamecharacters/buffs/enemy_buffs/TariffAura';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class TollCollectorGoneMad extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Mad Toll Collector',
+            portraitName: 'Lost Accountant',
+            maxHitpoints: 28,
+            description: 'Ink-stained revenant shrieking about unpaid fares.'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new TariffAura());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        return [new AttackIntent({ baseDamage: 6, owner: this, target: TargetingUtils.getInstance().selectRandomPlayerCharacter() }).withTitle('Ledger Smash')];
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/LeechingBite.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/LeechingBite.ts
@@ -1,0 +1,29 @@
+import { ActionManager } from "../../../utils/ActionManager";
+import { DamageInfo } from "../../../rules/DamageInfo";
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+
+export class LeechingBite extends AbstractBuff {
+    constructor(healAmount: number = 2) {
+        super();
+        this.stacks = healAmount;
+        this.isDebuff = false;
+        this.imageName = "leech";
+    }
+
+    override getDisplayName(): string {
+        return "Leeching Bite";
+    }
+
+    override getDescription(): string {
+        return `When this enemy deals damage, it heals ${this.getStacksDisplayText()} HP.`;
+    }
+
+    override onOwnerStriking_CannotModifyDamage(struckUnit: BaseCharacter, cardPlayedIfAny: PlayableCard | null, damageInfo: DamageInfo): void {
+        const owner = this.getOwnerAsCharacter();
+        if (owner && damageInfo.unblockedDamage > 0) {
+            ActionManager.getInstance().heal(owner, this.stacks);
+        }
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/SignalInterference.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/SignalInterference.ts
@@ -1,0 +1,31 @@
+import { BaseCharacter } from "../../BaseCharacter";
+import { Team } from "../../AbstractCard";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { TargetingUtils } from "../../../utils/TargetingUtils";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class SignalInterference extends AbstractBuff {
+    constructor(damage: number = 2) {
+        super();
+        this.stacks = damage;
+        this.isDebuff = false;
+        this.imageName = "lightning-bolt";
+    }
+
+    override getDisplayName(): string {
+        return "Signal Interference";
+    }
+
+    override getDescription(): string {
+        return `Whenever a player card is played, deal ${this.getStacksDisplayText()} damage to a random player.`;
+    }
+
+    override onAnyCardPlayedByAnyone(playedCard: PlayableCard, target?: BaseCharacter): void {
+        const ownerOfCard = playedCard?.owningCharacter;
+        if (ownerOfCard && ownerOfCard.team === Team.ALLY) {
+            const randomPlayer = TargetingUtils.getInstance().selectRandomPlayerCharacter();
+            ActionManager.getInstance().dealDamage({ baseDamageAmount: this.stacks, target: randomPlayer, sourceCharacter: this.getOwnerAsCharacter(), fromAttack: false });
+        }
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/TariffAura.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/TariffAura.ts
@@ -1,0 +1,30 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { ActionManager } from "../../../utils/ActionManager";
+import { GameState } from "../../../rules/GameState";
+import { Tariffed } from "../playable_card/Tariffed";
+import Phaser from "phaser";
+
+export class TariffAura extends AbstractBuff {
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "coins";
+    }
+
+    override getDisplayName(): string {
+        return "Mad Toll";
+    }
+
+    override getDescription(): string {
+        return "At the start of each turn, a random card in hand costs 1 more energy.";
+    }
+
+    override onTurnStart(): void {
+        const hand = GameState.getInstance().combatState.currentHand;
+        if (hand.length > 0) {
+            const randomIndex = Phaser.Math.Between(0, hand.length - 1);
+            const randomCard = hand[randomIndex];
+            ActionManager.getInstance().applyBuffToCard(randomCard, new Tariffed());
+        }
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/ToxicRetaliation.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/ToxicRetaliation.ts
@@ -1,0 +1,28 @@
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { DamageInfo } from "../../../rules/DamageInfo";
+import { Poisoned } from "../standard/Poisoned";
+
+export class ToxicRetaliation extends AbstractBuff {
+    constructor(stacks: number = 2) {
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "toxic";
+    }
+
+    override getDisplayName(): string {
+        return "Toxic Retaliation";
+    }
+
+    override getDescription(): string {
+        return `When struck, apply ${this.getStacksDisplayText()} Poison to the attacker.`;
+    }
+
+    override onOwnerStruck_CannotModifyDamage(strikingUnit: BaseCharacter, cardPlayedIfAny: PlayableCard | null, damageInfo: DamageInfo): void {
+        if (strikingUnit) {
+            this.actionManager.applyBuffToCharacter(strikingUnit, new Poisoned(this.stacks));
+        }
+    }
+}

--- a/src/gamecharacters/buffs/playable_card/Tariffed.ts
+++ b/src/gamecharacters/buffs/playable_card/Tariffed.ts
@@ -1,0 +1,22 @@
+import { AbstractBuff } from "../AbstractBuff";
+
+export class Tariffed extends AbstractBuff {
+    constructor(stacks: number = 1) {
+        super();
+        this.isDebuff = true;
+        this.stacks = stacks;
+        this.imageName = "coins";
+    }
+
+    override getDisplayName(): string {
+        return "Tariffed";
+    }
+
+    override getDescription(): string {
+        return `Costs ${this.getStacksDisplayText()} more energy.`;
+    }
+
+    override energyCostModifier(): number {
+        return this.stacks;
+    }
+}


### PR DESCRIPTION
## Summary
- implement new Tariffed card debuff that raises energy cost
- rework Mad Toll Aura so a random card is Tariffed each turn

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'phaser')*