### PR TITLE
Add German Zeppelin Grenadier and update AuditPressure

### DIFF
--- a/src/docs/flavor/factions_and_acts.md
+++ b/src/docs/flavor/factions_and_acts.md
@@ -12,7 +12,7 @@ here's the concise, cleaned-up summary of your roguelike's acts and faction conc
 * **Act 2: Deep France**
 
   * Environment: Frozen trenches, Napoleonic revivalist "Empire of the Abyss," trench warfare aesthetics with industrial-revolution weaponry.
-  * Enemies: French undead imperialists, Napoleon’s old guard, mitrailleuse-organists, grenadiers, imperial auditor-wraiths, and trench engineers.  Also their German opposition.
+  * Enemies: French undead imperialists, Napoleon’s old guard, mitrailleuse-organists, grenadiers, and trench engineers. German opposition fields cryo-lancers, zeppelin grenadiers, and uhlan riders.
 
 CENTRAL CONFLICT:  The French vs the Germans; the French are led by Napoleon Bonaparte, who has been exiled from the surface.
 
@@ -43,8 +43,8 @@ CENTRAL CONFLICT:  The French vs the Germans; the French are led by Napoleon Bon
 
 * **Reichsinfernokorps (Germany)**
 
-  * Visuals: Gunmetal greatcoats, spiked Pickelhaube with quartz, zeppelin-inspired aesthetics.
-  * Flavor: Imperial German industrial/scientific-military colonization, rigorous militarized science.
+  * Visuals: Gunmetal greatcoats, spiked Pickelhaube studded with quartz, and personal zeppelin harnesses with cryo-tech condensers.
+  * Flavor: Imperial German industrial/scientific-military colonization backed by experimental cryogenic weaponry and rigorous discipline.
 
 * **Imperial Hell Post (Britain)**
 

--- a/src/docs/mechanics/enemy_power_rules.md
+++ b/src/docs/mechanics/enemy_power_rules.md
@@ -58,3 +58,13 @@ In addition to the balance rules above, enemies in Act 2 and Act 3 should have s
 Generally, you'll want to have these in the form of a "when the player does x, cause y effect" trigger (see triggers_and_effects_options for some ideas on this).  NOTE that the goal is for the player to be able to play around the buff/debuff; "the player has one less energy per turn" is an example of a bad concept for a debuff on the player since the player can't really do anything about that.  "Whenever the player plays a card, discard a card at random" is a more interesting buff since it forces the player to reprioritize the cards they play (this is just an example, do not use this specific concept.)  "This enemy takes 2x damage from burning" is also a good option since it pushes the player to use the Burning status effect more often.
 
 NOTE that you may use secondaryStacks on the AbstractBuff object if the buff needs to keep a counter of any sort.
+
+### Negative design example: unused-energy triggers
+
+`Audit Pressure` once penalized players for leaving energy unspent at the end of a turn.  Because unused energy is extremely rare in normal play, the effect almost never fired and therefore failed to influence player choices.  Worse, the buff repeatedly lowered party **Lethality**, stretching fights out rather than adding tension.
+
+### Better approach: card-count audits
+
+Revised `Audit Pressure` now counts how many cards the party plays each turn.  If they play more than three, everyone loses 1 Dexterity at turn end.  Players can choose to hold back cards to avoid the penalty, so the mechanic actually shapes decisions without permanently stifling their damage output.
+
+Repeatedly lowering Lethality is discouraged; if you must scale a stat down over time, hit Dexterity instead so combats don’t drag on interminably.

--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -39,10 +39,13 @@ import { HiveBroodmother } from './monsters/act2_segment1/HiveBroodmother';
 import { Lexiophage } from './monsters/act2_segment1/Lexiophage';
 import { SlothfulSentinel } from './monsters/act2_segment1/SlothfulSentinel';
 import { WeirdTree } from './monsters/act2_segment1/WeirdTree';
+import { MitrailleuseOrganist } from './monsters/act2_segment1/MitrailleuseOrganist';
+import { OldGuardGrenadier } from './monsters/act2_segment1/OldGuardGrenadier';
 import { Artiste } from './monsters/act2_segment2/Artiste';
 import { EschatonMirror } from './monsters/act2_segment2/EschatonMirror';
 import { FrenchRestauranteur } from './monsters/act2_segment2/FrenchRestauranteur';
 import { VeilSculptor } from './monsters/act2_segment2/VeilSculptor';
+import { ZeppelinGrenadier } from './monsters/act2_segment2/ZeppelinGrenadier';
 // Define new character classes
 export class ClockworkAbomination extends AutomatedCharacter {
     constructor() {
@@ -190,6 +193,12 @@ export class ActSegment {
         },
         {
             enemies: [new WeirdTree(), new WeirdTree()]
+        },
+        {
+            enemies: [new MitrailleuseOrganist()]
+        },
+        {
+            enemies: [new OldGuardGrenadier()]
         }
     ]);
 
@@ -205,6 +214,9 @@ export class ActSegment {
         },
         {
             enemies: [new EschatonMirror()]
+        },
+        {
+            enemies: [new ZeppelinGrenadier()]
         }
     ]);
     

--- a/src/encounters/monsters/act2_segment1/MitrailleuseOrganist.ts
+++ b/src/encounters/monsters/act2_segment1/MitrailleuseOrganist.ts
@@ -1,0 +1,27 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+
+export class MitrailleuseOrganist extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Mitrailleuse Organist',
+            portraitName: 'Machine Gunner Demon',
+            maxHitpoints: 100,
+            description: 'A frenzied gunner pounding a demonic organ that spits bullets.'
+        });
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Burst Fire'),
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Burst Fire'),
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Burst Fire')
+            ],
+            [
+                new AttackIntent({ baseDamage: 14, owner: this }).withTitle('Finale Volley')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment1/OldGuardGrenadier.ts
+++ b/src/encounters/monsters/act2_segment1/OldGuardGrenadier.ts
@@ -1,0 +1,27 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { DoNotLookAtMe } from '../../../gamecharacters/buffs/enemy_buffs/DoNotLookAtMe';
+
+export class OldGuardGrenadier extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Old Guard Grenadier',
+            portraitName: 'Napoleonic Zombie',
+            maxHitpoints: 80,
+            description: 'Veteran of countless wars, lobbing unstable grenades.'
+        });
+        this.buffs.push(new DoNotLookAtMe(1));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 6, owner: this }).withTitle('Grenade Toss')
+            ],
+            [
+                new AttackIntent({ baseDamage: 18, owner: this }).withTitle('Bayonet Charge')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment2/ZeppelinGrenadier.ts
+++ b/src/encounters/monsters/act2_segment2/ZeppelinGrenadier.ts
@@ -1,0 +1,28 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, BlockForSelfIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { AuditPressure } from '../../../gamecharacters/buffs/enemy_buffs/AuditPressure';
+
+export class ZeppelinGrenadier extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Zeppelin Grenadier',
+            portraitName: 'Zeppelin Trooper',
+            maxHitpoints: 90,
+            description: 'A German trooper dropping cryo-grenades from a personal zeppelin.'
+        });
+        this.buffs.push(new AuditPressure(1));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 5, owner: this }).withTitle('Frosty Fizzle')
+            ],
+            [
+                new BlockForSelfIntent({ blockAmount: 10, owner: this }).withTitle('Balloon Barricade'),
+                new AttackIntent({ baseDamage: 12, owner: this }).withTitle('Zeppelin Zap')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/AuditPressure.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/AuditPressure.ts
@@ -1,0 +1,47 @@
+import { Team } from "../../AbstractCard";
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { Dexterity } from "../persona/Dexterity";
+import { GameState } from "../../../rules/GameState";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class AuditPressure extends AbstractBuff {
+    private cardsPlayedThisTurn = 0;
+
+    constructor(stacks: number = 1) {
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "scroll";
+    }
+
+    override getDisplayName(): string {
+        return "Audit Pressure";
+    }
+
+    override getDescription(): string {
+        return `If the party plays more than three cards in a turn, everyone loses ${this.getStacksDisplayText()} Dexterity at end of turn.`;
+    }
+
+    override onAnyCardPlayedByAnyone(playedCard: PlayableCard, _target?: BaseCharacter): void {
+        const ownerOfCard = playedCard?.owningCharacter;
+        if (ownerOfCard && ownerOfCard.team === Team.ALLY) {
+            this.cardsPlayedThisTurn++;
+        }
+    }
+
+    override onTurnEnd(): void {
+        if (this.cardsPlayedThisTurn > 3) {
+            const actionManager = ActionManager.getInstance();
+            GameState.getInstance().combatState.playerCharacters.forEach(pc => {
+                actionManager.applyBuffToCharacterOrCard(pc, new Dexterity(-this.stacks));
+            });
+        }
+        this.cardsPlayedThisTurn = 0;
+    }
+
+    override onTurnStart(): void {
+        this.cardsPlayedThisTurn = 0;
+    }
+}


### PR DESCRIPTION
## Summary
- replace Imperial Auditor Wraith with Zeppelin Grenadier enemy and update encounters
- rework `AuditPressure` buff so it penalizes playing more than three cards and reduces Dexterity
- document why unused-energy debuffs are bad and describe the improved mechanic
- list German cryo troops in factions documentation

## Testing
- `npm run build` *(fails: webpack not found)*