### PR TITLE
Add necromantic buffs and update Deep France

### DIFF
--- a/src/docs/flavor/factions_and_acts.md
+++ b/src/docs/flavor/factions_and_acts.md
@@ -11,10 +11,11 @@ here's the concise, cleaned-up summary of your roguelike's acts and faction conc
 
 * **Act 2: Deep France**
 
-  * Environment: Frozen trenches, Napoleonic revivalist "Empire of the Abyss," trench warfare aesthetics with industrial-revolution weaponry.
-  * Enemies: French undead imperialists, Napoleon’s old guard, mitrailleuse-organists, grenadiers, imperial auditor-wraiths, and trench engineers.  Also their German opposition.
+  * Environment: Frozen trenches where necromancers prop up an undead Napoleonic empire.  Trench warfare mixes with grisly rituals and industrial weaponry.
+  * Enemies: Reanimated infantry such as mitrailleuse-organists and old guard grenadiers, plus spectral auditors and trench engineers.  German cryo‑troops and zeppelin grenadiers oppose them.
+  * Default undead traits: **Implacable** (revive at ¼ HP a limited number of times), **Decaying** (lose HP each turn ignoring armor), and **Minion** (dies if only minions remain).
 
-CENTRAL CONFLICT:  The French vs the Germans; the French are led by Napoleon Bonaparte, who has been exiled from the surface.
+CENTRAL CONFLICT:  The necromantic French empire battles the German Reichsinfernokorps; Napoleon Bonaparte commands from exile.
 
 * **Act 3 (options suggested):**
 

--- a/src/docs/mechanics/enemy_power_rules.md
+++ b/src/docs/mechanics/enemy_power_rules.md
@@ -58,3 +58,7 @@ In addition to the balance rules above, enemies in Act 2 and Act 3 should have s
 Generally, you'll want to have these in the form of a "when the player does x, cause y effect" trigger (see triggers_and_effects_options for some ideas on this).  NOTE that the goal is for the player to be able to play around the buff/debuff; "the player has one less energy per turn" is an example of a bad concept for a debuff on the player since the player can't really do anything about that.  "Whenever the player plays a card, discard a card at random" is a more interesting buff since it forces the player to reprioritize the cards they play (this is just an example, do not use this specific concept.)  "This enemy takes 2x damage from burning" is also a good option since it pushes the player to use the Burning status effect more often.
 
 NOTE that you may use secondaryStacks on the AbstractBuff object if the buff needs to keep a counter of any sort.
+
+## Negative example: unused-energy triggers
+
+Buffs that punish players for ending their turn with leftover energy rarely fire. Most players spend all of their energy every round, so a rule like “if you have unused energy, lose Lethality” ends up irrelevant. Instead, track something the party actually does—such as how many cards they played. For example, **Audit Pressure** reduces party Dexterity at turn end only if more than three cards were played that round.

--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -39,10 +39,13 @@ import { HiveBroodmother } from './monsters/act2_segment1/HiveBroodmother';
 import { Lexiophage } from './monsters/act2_segment1/Lexiophage';
 import { SlothfulSentinel } from './monsters/act2_segment1/SlothfulSentinel';
 import { WeirdTree } from './monsters/act2_segment1/WeirdTree';
+import { MitrailleuseOrganist } from './monsters/act2_segment1/MitrailleuseOrganist';
+import { OldGuardGrenadier } from './monsters/act2_segment1/OldGuardGrenadier';
 import { Artiste } from './monsters/act2_segment2/Artiste';
 import { EschatonMirror } from './monsters/act2_segment2/EschatonMirror';
 import { FrenchRestauranteur } from './monsters/act2_segment2/FrenchRestauranteur';
 import { VeilSculptor } from './monsters/act2_segment2/VeilSculptor';
+import { ImperialAuditorWraith } from './monsters/act2_segment2/ImperialAuditorWraith';
 // Define new character classes
 export class ClockworkAbomination extends AutomatedCharacter {
     constructor() {
@@ -190,6 +193,12 @@ export class ActSegment {
         },
         {
             enemies: [new WeirdTree(), new WeirdTree()]
+        },
+        {
+            enemies: [new MitrailleuseOrganist()]
+        },
+        {
+            enemies: [new OldGuardGrenadier()]
         }
     ]);
 
@@ -205,6 +214,9 @@ export class ActSegment {
         },
         {
             enemies: [new EschatonMirror()]
+        },
+        {
+            enemies: [new ImperialAuditorWraith()]
         }
     ]);
     

--- a/src/encounters/monsters/act2_segment1/MitrailleuseOrganist.ts
+++ b/src/encounters/monsters/act2_segment1/MitrailleuseOrganist.ts
@@ -1,0 +1,33 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { Implacable } from '../../../gamecharacters/buffs/standard/Implacable';
+import { Decaying } from '../../../gamecharacters/buffs/enemy_buffs/Decaying';
+import { Minion } from '../../../gamecharacters/buffs/enemy_buffs/Minion';
+
+export class MitrailleuseOrganist extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Mitrailleuse Organist',
+            portraitName: 'Machine Gunner Demon',
+            maxHitpoints: 100,
+            description: 'A frenzied gunner pounding a demonic organ that spits bullets.'
+        });
+        this.buffs.push(new Implacable(1));
+        this.buffs.push(new Decaying(2));
+        this.buffs.push(new Minion());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Bullet Barcarolle'),
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Bullet Barcarolle'),
+                new AttackAllPlayerCharactersIntent({ baseDamage: 4, owner: this }).withTitle('Bullet Barcarolle')
+            ],
+            [
+                new AttackIntent({ baseDamage: 14, owner: this }).withTitle('Fortissimo Finale')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment1/OldGuardGrenadier.ts
+++ b/src/encounters/monsters/act2_segment1/OldGuardGrenadier.ts
@@ -1,0 +1,33 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { DoNotLookAtMe } from '../../../gamecharacters/buffs/enemy_buffs/DoNotLookAtMe';
+import { Implacable } from '../../../gamecharacters/buffs/standard/Implacable';
+import { Decaying } from '../../../gamecharacters/buffs/enemy_buffs/Decaying';
+import { Minion } from '../../../gamecharacters/buffs/enemy_buffs/Minion';
+
+export class OldGuardGrenadier extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Old Guard Grenadier',
+            portraitName: 'Napoleonic Zombie',
+            maxHitpoints: 80,
+            description: 'Veteran of countless wars, lobbing unstable grenades.'
+        });
+        this.buffs.push(new DoNotLookAtMe(1));
+        this.buffs.push(new Implacable(1));
+        this.buffs.push(new Decaying(2));
+        this.buffs.push(new Minion());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 6, owner: this }).withTitle('Grisly Grenade')
+            ],
+            [
+                new AttackIntent({ baseDamage: 18, owner: this }).withTitle('Bonaparte Bayonet')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment2/ImperialAuditorWraith.ts
+++ b/src/encounters/monsters/act2_segment2/ImperialAuditorWraith.ts
@@ -1,0 +1,32 @@
+import { AbstractIntent, AttackIntent, BlockForSelfIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { AuditPressure } from '../../../gamecharacters/buffs/enemy_buffs/AuditPressure';
+import { Implacable } from '../../../gamecharacters/buffs/standard/Implacable';
+import { Decaying } from '../../../gamecharacters/buffs/enemy_buffs/Decaying';
+
+export class ImperialAuditorWraith extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Imperial Auditor-Wraith',
+            portraitName: 'Ghost Bureaucrat',
+            maxHitpoints: 90,
+            description: 'A translucent bureaucrat tallying every misused resource.'
+        });
+        this.buffs.push(new AuditPressure(1));
+        this.buffs.push(new Implacable(1));
+        this.buffs.push(new Decaying(2));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackIntent({ baseDamage: 12, owner: this }).withTitle('Spectral Surcharge')
+            ],
+            [
+                new BlockForSelfIntent({ blockAmount: 10, owner: this }).withTitle('Audit Aegis')
+            ]
+        ];
+
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/AuditPressure.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/AuditPressure.ts
@@ -1,0 +1,42 @@
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { Dexterity } from "../persona/Dexterity";
+import { GameState } from "../../../rules/GameState";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class AuditPressure extends AbstractBuff {
+    constructor(stacks: number = 1) {
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "scroll";
+        this.showSecondaryStacks = true;
+        this.secondaryStacks = 0;
+    }
+
+    override getDisplayName(): string {
+        return "Audit Pressure";
+    }
+
+    override getDescription(): string {
+        return `If more than three cards were played this turn, all players lose ${this.getStacksDisplayText()} Dexterity.`;
+    }
+
+    override onAnyCardPlayedByAnyone(playedCard: PlayableCard): void {
+        const gameState = GameState.getInstance();
+        if (gameState.combatState.playerCharacters.some(pc => pc === playedCard.owningCharacter)) {
+            this.secondaryStacks++;
+        }
+    }
+
+    override onTurnEnd(): void {
+        const gameState = GameState.getInstance();
+        if (this.secondaryStacks > 3) {
+            const actionManager = ActionManager.getInstance();
+            gameState.combatState.playerCharacters.forEach(pc => {
+                actionManager.applyBuffToCharacterOrCard(pc, new Dexterity(-this.stacks));
+            });
+        }
+        this.secondaryStacks = 0;
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/Decaying.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/Decaying.ts
@@ -1,0 +1,26 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class Decaying extends AbstractBuff {
+    constructor(stacks: number = 1) {
+        super();
+        this.stacks = stacks;
+        this.isDebuff = true;
+        this.imageName = "decay";
+    }
+
+    override getDisplayName(): string {
+        return "Decaying";
+    }
+
+    override getDescription(): string {
+        return `Lose ${this.getStacksDisplayText()} HP at end of turn (ignores block).`;
+    }
+
+    override onTurnEnd(): void {
+        const owner = this.getOwnerAsCharacter();
+        if (owner) {
+            ActionManager.getInstance().dealDamage({ baseDamageAmount: this.stacks, target: owner, fromAttack: false, ignoresBlock: true });
+        }
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/Minion.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/Minion.ts
@@ -1,0 +1,34 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { GameState } from "../../../rules/GameState";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class Minion extends AbstractBuff {
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "minion";
+    }
+
+    override getDisplayName(): string {
+        return "Minion";
+    }
+
+    override getDescription(): string {
+        return "Dies if no non-minion enemies remain.";
+    }
+
+    override onTurnStart(): void {
+        const owner = this.getOwnerAsCharacter();
+        if (!owner) return;
+        const gameState = GameState.getInstance();
+        const livingEnemies = gameState.combatState.enemies.filter(e => e.hitpoints > 0);
+        const nonMinionAlive = livingEnemies.some(e => !e.buffs.some(b => b instanceof Minion));
+        if (!nonMinionAlive) {
+            livingEnemies.forEach(enemy => {
+                if (enemy.buffs.some(b => b instanceof Minion)) {
+                    ActionManager.getInstance().dealDamage({ baseDamageAmount: enemy.hitpoints, target: enemy, fromAttack: false, ignoresBlock: true });
+                }
+            });
+        }
+    }
+}

--- a/src/gamecharacters/buffs/standard/Implacable.ts
+++ b/src/gamecharacters/buffs/standard/Implacable.ts
@@ -1,11 +1,14 @@
 import { AbstractBuff } from "../AbstractBuff";
+import type { IBaseCharacter } from "../../IBaseCharacter";
+import type { PlayableCard } from "../../PlayableCard";
+import type { DamageInfo } from "../../../rules/DamageInfo";
 
 export class Implacable extends AbstractBuff {
     constructor(stacks: number = 1) {
         super();
         this.stacks = stacks;
         this.stackable = true;
-        this.imageName = "shield"; // Replace with actual icon name if available
+        this.imageName = "skull";
     }
 
     override getDisplayName(): string {
@@ -13,16 +16,15 @@ export class Implacable extends AbstractBuff {
     }
 
     override getDescription(): string {
-        return `At the start of turn, gain ${this.getStacksDisplayText()} Block.`;
+        return `Revives at ¼ HP when killed, ${this.getStacksDisplayText()} trigger(s) left.`;
     }
 
-    override onTurnStart(): void {
+    override onOwnerStruck_CannotModifyDamage(_strikingUnit: IBaseCharacter | null, _cardPlayedIfAny: PlayableCard | null, _damageInfo: DamageInfo): void {
         const owner = this.getOwnerAsCharacter();
-        if (owner) {
-            this.actionManager.applyBlock({
-                baseBlockValue: this.stacks,
-                blockTargetCharacter: owner
-            });
+        if (owner && owner.hitpoints <= 0 && this.stacks > 0) {
+            owner.hitpoints = Math.ceil(owner.maxHitpoints / 4);
+            this.stacks -= 1;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- give Deep France enemies new undead-themed buffs
- add comedic attack names
- document the necromantic French and unused-energy design trap

## Testing
- `npm run build` *(fails: webpack not found)*