### PR TITLE
Add Deep France enemy trio

### DIFF
--- a/src/docs/mechanics/enemy_power_rules.md
+++ b/src/docs/mechanics/enemy_power_rules.md
@@ -59,6 +59,11 @@ Generally, you'll want to have these in the form of a "when the player does x, c
 
 NOTE that you may use secondaryStacks on the AbstractBuff object if the buff needs to keep a counter of any sort.
 
+*New rule:* **Do not store private mutable variables on buffs.**  If a buff needs
+to keep temporary state—such as whether it has been triggered this turn—use the
+`secondaryStacks` field instead. This keeps buff data visible and easier to
+debug.
+
 ## Negative example: unused-energy triggers
 
 Buffs that punish players for ending their turn with leftover energy rarely fire. Most players spend all of their energy every round, so a rule like “if you have unused energy, lose Lethality” ends up irrelevant. Instead, track something the party actually does—such as how many cards they played. For example, **Audit Pressure** reduces party Dexterity at turn end only if more than three cards were played that round.

--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -41,11 +41,14 @@ import { SlothfulSentinel } from './monsters/act2_segment1/SlothfulSentinel';
 import { WeirdTree } from './monsters/act2_segment1/WeirdTree';
 import { MitrailleuseOrganist } from './monsters/act2_segment1/MitrailleuseOrganist';
 import { OldGuardGrenadier } from './monsters/act2_segment1/OldGuardGrenadier';
+import { TrenchEngineer } from './monsters/act2_segment1/TrenchEngineer';
 import { Artiste } from './monsters/act2_segment2/Artiste';
 import { EschatonMirror } from './monsters/act2_segment2/EschatonMirror';
 import { FrenchRestauranteur } from './monsters/act2_segment2/FrenchRestauranteur';
 import { VeilSculptor } from './monsters/act2_segment2/VeilSculptor';
 import { ImperialAuditorWraith } from './monsters/act2_segment2/ImperialAuditorWraith';
+import { Grafter } from './monsters/act2_segment2/Grafter';
+import { ZeppelinGrenadier } from './monsters/act2_segment2/ZeppelinGrenadier';
 // Define new character classes
 export class ClockworkAbomination extends AutomatedCharacter {
     constructor() {
@@ -199,6 +202,9 @@ export class ActSegment {
         },
         {
             enemies: [new OldGuardGrenadier()]
+        },
+        {
+            enemies: [new TrenchEngineer(), new TrenchEngineer()]
         }
     ]);
 
@@ -217,6 +223,12 @@ export class ActSegment {
         },
         {
             enemies: [new ImperialAuditorWraith()]
+        },
+        {
+            enemies: [new ZeppelinGrenadier(), new ZeppelinGrenadier()]
+        },
+        {
+            enemies: [new Grafter()]
         }
     ]);
     

--- a/src/encounters/monsters/act2_segment1/TrenchEngineer.ts
+++ b/src/encounters/monsters/act2_segment1/TrenchEngineer.ts
@@ -1,0 +1,70 @@
+import { AbstractIntent, AttackIntent, BlockForSelfIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { AbstractBuff } from "../../../gamecharacters/buffs/AbstractBuff";
+import { Lethality } from "../../../gamecharacters/buffs/standard/Lethality";
+import { ActionManager } from "../../../utils/ActionManager";
+import { DamageInfo } from "../../../rules/DamageInfo";
+
+class Entrench extends AbstractBuff {
+    readonly strengthGain: number;
+
+    constructor(blockAmount: number = 6, strengthGain: number = 1) {
+        super();
+        this.isDebuff = false;
+        this.imageName = "shield";
+        this.stacks = blockAmount;
+        this.secondaryStacks = 0; // 0 = not struck this turn
+        this.strengthGain = strengthGain;
+    }
+
+    override getDisplayName(): string {
+        return "Entrench";
+    }
+
+    override getDescription(): string {
+        return `If unhurt this turn, gain ${this.stacks} Block and ${this.strengthGain} Strength at end of turn.`;
+    }
+
+    override onTurnStart(): void {
+        this.secondaryStacks = 0;
+    }
+
+    override onOwnerStruck_CannotModifyDamage(_striker: any, _card: any, _info: DamageInfo): void {
+        this.secondaryStacks = 1;
+    }
+
+    override onTurnEnd(): void {
+        if (this.secondaryStacks === 0) {
+            const owner = this.getOwnerAsCharacter();
+            if (owner) {
+                ActionManager.getInstance().applyBlock({ baseBlockValue: this.stacks, blockSourceCharacter: owner, blockTargetCharacter: owner });
+                ActionManager.getInstance().applyBuffToCharacterOrCard(owner, new Lethality(this.strengthGain));
+            }
+        }
+    }
+}
+
+export class TrenchEngineer extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Trench Engineer',
+            portraitName: 'Napoleonic Zombie',
+            maxHitpoints: 80,
+            description: 'Undead sapper laying fortifications and traps.'
+        });
+        this.buffs.push(new Entrench());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackIntent({ baseDamage: 8, owner: this }).withTitle('Bayonet Jab'),
+                new BlockForSelfIntent({ blockAmount: 6, owner: this }).withTitle('Sandbag Wall')
+            ],
+            [
+                new AttackIntent({ baseDamage: 14, owner: this }).withTitle('Shrapnel Charge')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment2/Grafter.ts
+++ b/src/encounters/monsters/act2_segment2/Grafter.ts
@@ -1,0 +1,49 @@
+import { AbstractIntent, AttackIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { AbstractBuff } from "../../../gamecharacters/buffs/AbstractBuff";
+import { PlayableCard } from "../../../gamecharacters/PlayableCard";
+import { CardType } from "../../../gamecharacters/Primitives";
+import { ActionManager } from "../../../utils/ActionManager";
+import { BaseCharacter } from "../../../gamecharacters/BaseCharacter";
+
+class PatchworkSurgeon extends AbstractBuff {
+    constructor(healAmount: number = 5) {
+        super();
+        this.isDebuff = false;
+        this.imageName = "syringe";
+        this.stacks = healAmount;
+    }
+
+    override getDisplayName(): string { return "Patchwork Surgeon"; }
+
+    override getDescription(): string {
+        return `Whenever a player plays a Power card, this enemy heals ${this.getStacksDisplayText()} HP.`;
+    }
+
+    override onAnyCardPlayedByAnyone(card: PlayableCard, _target?: BaseCharacter): void {
+        const owner = this.getOwnerAsCharacter();
+        if (owner && card.owningCharacter && card.owningCharacter.isPlayerCharacter() && card.cardType === CardType.POWER) {
+            ActionManager.getInstance().heal(owner, this.stacks);
+        }
+    }
+}
+
+export class Grafter extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Grafter',
+            portraitName: 'Clockwork Abomination',
+            maxHitpoints: 90,
+            description: 'A trench medic stitching the fallen into grisly servitors.'
+        });
+        this.buffs.push(new PatchworkSurgeon());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new AttackIntent({ baseDamage: 12, owner: this }).withTitle('Bone Saw')],
+            [new AttackIntent({ baseDamage: 6, owner: this }).withTitle('Quick Slash'), new AttackIntent({ baseDamage: 6, owner: this }).withTitle('Quick Slash')]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_segment2/ZeppelinGrenadier.ts
+++ b/src/encounters/monsters/act2_segment2/ZeppelinGrenadier.ts
@@ -1,0 +1,49 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { AbstractBuff } from "../../../gamecharacters/buffs/AbstractBuff";
+import { PlayableCard } from "../../../gamecharacters/PlayableCard";
+import { ActionManager } from "../../../utils/ActionManager";
+import { BaseCharacter } from "../../../gamecharacters/BaseCharacter";
+
+class ShrapnelClouds extends AbstractBuff {
+    constructor(damage: number = 1) {
+        super();
+        this.stacks = damage;
+        this.isDebuff = false;
+        this.imageName = "grenade";
+    }
+
+    override getDisplayName(): string { return "Shrapnel Clouds"; }
+
+    override getDescription(): string {
+        return `Whenever a player draws a card, they take ${this.getStacksDisplayText()} damage.`;
+    }
+
+    override onAnyCardDrawn(card: PlayableCard): void {
+        const owner = this.getOwnerAsCharacter();
+        const player = card.owningCharacter as BaseCharacter | undefined;
+        if (owner && player && player.isPlayerCharacter()) {
+            ActionManager.getInstance().dealDamage({ baseDamageAmount: this.stacks, target: player, sourceCharacter: owner, fromAttack: false });
+        }
+    }
+}
+
+export class ZeppelinGrenadier extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Zeppelin Grenadier',
+            portraitName: 'Napoleonic Zombie',
+            maxHitpoints: 85,
+            description: 'German aerial trooper dropping shrapnel from above.'
+        });
+        this.buffs.push(new ShrapnelClouds(1));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new AttackAllPlayerCharactersIntent({ baseDamage: 5, owner: this }).withTitle('Bombing Run')],
+            [new AttackIntent({ baseDamage: 15, owner: this }).withTitle('Focused Bomb')]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}


### PR DESCRIPTION
## Summary
- add TrenchEngineer, ZeppelinGrenadier and Grafter enemies for Act 2
- wire new foes into EncounterManager
- document rule prohibiting private mutable buff fields
- refactor Entrench and PatchworkSurgeon buffs to use stacks/secondaryStacks

## Testing
- `npm run build` *(fails: webpack not found)*