### PR TITLE
Add new Styx Delta bosses

### DIFF
--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -13,6 +13,9 @@ import { GameState } from '../rules/GameState';
 import { CardModifier } from '../rules/modifiers/AbstractCardModifier';
 import { RestEvent } from './events/RestEvent';
 import { FrenchBlindProphetess } from './monsters/act1_boss/FrenchBlindProphetess';
+import { BloatedTreasurer } from './monsters/act1_boss/BloatedTreasurer';
+import { HermitProphetOfTheDelta } from './monsters/act1_boss/HermitProphetOfTheDelta';
+import { HermitsTreasure } from './monsters/act1_boss/HermitsTreasure';
 import { Brigand } from './monsters/act1_segment1/act1_segment0/Brigand';
 import { StyxConstrictor } from './monsters/act1_segment1/act1_segment0/Hellworm';
 import { BogLampreyOUS } from './monsters/act1_segment1/BogLampreyOUS';
@@ -154,6 +157,12 @@ export class ActSegment {
         {
             enemies: [new FrenchBlindProphetess(), new VeilCapacitor(), new VeilCapacitor()]
         },
+        {
+            enemies: [new BloatedTreasurer()]
+        },
+        {
+            enemies: [new HermitProphetOfTheDelta(), new HermitsTreasure()]
+        }
     ]);
     static readonly Act2_Segment0 = new ActSegmentData("Act 2 - Segment 1", 2, 0, [
         {

--- a/src/encounters/monsters/act1_boss/BloatedTreasurer.ts
+++ b/src/encounters/monsters/act1_boss/BloatedTreasurer.ts
@@ -1,0 +1,44 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, ApplyBuffToSelfIntent, DoSomethingIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { GreedIncarnate } from '../../../gamecharacters/buffs/enemy_buffs/GreedIncarnate';
+import { Lethality } from '../../../gamecharacters/buffs/standard/Lethality';
+import { Hazardous } from '../../../gamecharacters/buffs/playable_card/Hazardous';
+import { ValuableCargo } from '../../../gamecharacters/buffs/standard/ValuableCargo';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { GameState } from '../../../rules/GameState';
+
+export class BloatedTreasurer extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Bloated Treasurer',
+            portraitName: 'Lost Accountant',
+            maxHitpoints: 200,
+            description: 'corpulent guardian of illicit wealth'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new GreedIncarnate());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new AttackAllPlayerCharactersIntent({ baseDamage: 6, owner: this }).withTitle('Squeeze Dry')],
+            [new ApplyBuffToSelfIntent({ buff: new Lethality(4), owner: this }).withTitle('Inflation')],
+            [new DoSomethingIntent({
+                owner: this,
+                imageName: 'round-shield',
+                action: () => {
+                    this.actionManager.applyBlock({ baseBlockValue: 15, blockSourceCharacter: this, blockTargetCharacter: this });
+                    const state = GameState.getInstance();
+                    const cards = [...state.combatState.drawPile, ...state.combatState.currentDiscardPile];
+                    cards.forEach(card => {
+                        if (card.buffs.some(b => b instanceof ValuableCargo)) {
+                            this.actionManager.applyBuffToCard(card, new Hazardous(2));
+                        }
+                    });
+                }
+            }).withTitle('Undeclared Goods')]
+        ];
+
+        return intents[GameState.getInstance().combatState.currentTurn % intents.length];
+    }
+}

--- a/src/encounters/monsters/act1_boss/HermitProphetOfTheDelta.ts
+++ b/src/encounters/monsters/act1_boss/HermitProphetOfTheDelta.ts
@@ -1,0 +1,62 @@
+import { AbstractIntent, DoSomethingIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { Prophet } from '../../../gamecharacters/buffs/enemy_buffs/Prophet';
+import { HarbingerOfFate } from '../../../gamecharacters/buffs/enemy_buffs/HarbingerOfFate';
+import { Lethality } from '../../../gamecharacters/buffs/standard/Lethality';
+import { Cursed } from '../../../gamecharacters/buffs/standard/Cursed';
+import { Stress } from '../../../gamecharacters/buffs/standard/Stress';
+import { CardSize } from '../../../gamecharacters/Primitives';
+import { GameState } from '../../../rules/GameState';
+import { TargetingUtils } from '../../../utils/TargetingUtils';
+
+export class HermitProphetOfTheDelta extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Hermit Prophet',
+            portraitName: 'hermit',
+            maxHitpoints: 220,
+            description: 'A reclusive seer touched by dark tides.'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new Prophet(2));
+        this.buffs.push(new HarbingerOfFate());
+    }
+
+    get fateBuff(): HarbingerOfFate | undefined {
+        return this.buffs.find(b => b instanceof HarbingerOfFate) as HarbingerOfFate;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [new DoSomethingIntent({
+                owner: this,
+                imageName: 'knife-thrust',
+                action: () => {
+                    const target = TargetingUtils.getInstance().selectRandomPlayerCharacter();
+                    this.actionManager.dealDamage({ baseDamageAmount: 20, target, sourceCharacter: this });
+                    if (this.fateBuff && this.fateBuff.hasPlayedForeseen(target)) {
+                        this.actionManager.applyBuffToCharacter(target, new Stress(3));
+                    }
+                }
+            }).withTitle('Prophecy Fulfilled')],
+            [new DoSomethingIntent({
+                owner: this,
+                imageName: 'knife-thrust',
+                action: () => {
+                    const target = TargetingUtils.getInstance().selectRandomPlayerCharacter();
+                    this.actionManager.dealDamage({ baseDamageAmount: 18, target, sourceCharacter: this });
+                    this.actionManager.applyBuffToCharacter(target, new Cursed(2));
+                }
+            }).withTitle('Inevitability')],
+            [new DoSomethingIntent({
+                owner: this,
+                imageName: 'round-shield',
+                action: () => {
+                    this.actionManager.applyBlock({ baseBlockValue: 30, blockSourceCharacter: this, blockTargetCharacter: this });
+                    this.actionManager.applyBuffToCharacter(this, new Lethality(2));
+                }
+            }).withTitle('Path To Victory')]
+        ];
+        return intents[GameState.getInstance().combatState.currentTurn % intents.length];
+    }
+}

--- a/src/encounters/monsters/act1_boss/HermitsTreasure.ts
+++ b/src/encounters/monsters/act1_boss/HermitsTreasure.ts
@@ -1,0 +1,31 @@
+import { AbstractIntent, BlockForSelfIntent, DoSomethingIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { CardSize } from '../../../gamecharacters/Primitives';
+
+export class HermitsTreasure extends AutomatedCharacter {
+    private turnCount: number = 0;
+
+    constructor() {
+        super({
+            name: 'Hermit\'s Treasure',
+            portraitName: 'treasure',
+            maxHitpoints: 100,
+            description: 'A chest of unknown value.'
+        });
+        this.size = CardSize.LARGE;
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        this.turnCount++;
+        if (this.turnCount <= 3) {
+            return [new BlockForSelfIntent({ blockAmount: 10, owner: this }).withTitle('Guard Treasure')];
+        }
+        return [new DoSomethingIntent({
+            owner: this,
+            imageName: 'running-ninja',
+            action: () => {
+                this.hitpoints = 0;
+            }
+        }).withTitle('Flee')];
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/GreedIncarnate.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/GreedIncarnate.ts
@@ -1,0 +1,55 @@
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { Lethality } from "../standard/Lethality";
+import { DamageInfo } from "../../../rules/DamageInfo";
+import { ValuableCargo } from "../standard/ValuableCargo";
+import { GameState } from "../../../rules/GameState";
+
+export class GreedIncarnate extends AbstractBuff {
+    private damageThisTurn: number = 0;
+    private triggeredThisTurn: boolean = false;
+
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "greed";
+    }
+
+    override getDisplayName(): string { return "Greed Incarnate"; }
+
+    override getDescription(): string {
+        return "Cargo played heals this foe and grants Lethality. Taking 50 damage in a turn grants Obols. Gains half of any currency you acquire.";
+    }
+
+    override onTurnStart(): void {
+        this.damageThisTurn = 0;
+        this.triggeredThisTurn = false;
+    }
+
+    override onAnyCardPlayedByAnyone(card: PlayableCard): void {
+        if (card.buffs.some(b => b instanceof ValuableCargo)) {
+            const owner = this.getOwnerAsCharacter();
+            if (owner) {
+                this.actionManager.heal(owner, 10);
+                this.actionManager.applyBuffToCharacter(owner, new Lethality(3));
+            }
+        }
+    }
+
+    override onOwnerStruck_CannotModifyDamage(_strikingUnit: BaseCharacter | null, _cardPlayedIfAny: PlayableCard | null, damageInfo: DamageInfo): void {
+        this.damageThisTurn += damageInfo.unblockedDamageTaken;
+        if (!this.triggeredThisTurn && this.damageThisTurn >= 50) {
+            GameState.getInstance().obols += 15;
+            this.triggeredThisTurn = true;
+        }
+    }
+
+    /** Called when heroes gain currency. Returns remaining amount for the heroes. */
+    public stealCurrency(amount: number): number {
+        if (amount <= 0) return amount;
+        const steal = Math.ceil(amount / 2);
+        GameState.getInstance().obols += steal;
+        return amount - steal;
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/HarbingerOfFate.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/HarbingerOfFate.ts
@@ -1,0 +1,34 @@
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+import { Foreseen } from "./Foreseen";
+
+export class HarbingerOfFate extends AbstractBuff {
+    private playedForeseenThisCombat: Set<string> = new Set();
+
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "forward-sun";
+    }
+
+    override getDisplayName(): string { return "Harbinger of Fate"; }
+
+    override getDescription(): string {
+        return "Tracks those who play Foreseen cards.";
+    }
+
+    override onCombatStart(): void {
+        this.playedForeseenThisCombat.clear();
+    }
+
+    override onAnyCardPlayedByAnyone(card: PlayableCard): void {
+        if (card.buffs.some(b => b instanceof Foreseen) && card.owningCharacter && card.owningCharacter.isPlayerCharacter()) {
+            this.playedForeseenThisCombat.add(card.owningCharacter.id);
+        }
+    }
+
+    public hasPlayedForeseen(character: BaseCharacter): boolean {
+        return this.playedForeseenThisCombat.has(character.id);
+    }
+}

--- a/src/rules/GameState.ts
+++ b/src/rules/GameState.ts
@@ -41,6 +41,7 @@ export class GameState {
 
         this.sovereignInfernalNotes = 40
         this.britishPoundsSterling = 0
+        this.obols = 0
     }
 
     public cleanUpAfterLiquidation(){
@@ -93,6 +94,7 @@ export class GameState {
     public moneyInVault: number = 200
     public sovereignInfernalNotes: number = 0
     public britishPoundsSterling: number = 0
+    public obols: number = 0
 
     public combatState: CombatState = new CombatState()
 

--- a/src/utils/ActionManager.ts
+++ b/src/utils/ActionManager.ts
@@ -7,6 +7,7 @@ import type { BaseCharacter } from "../gamecharacters/BaseCharacter";
 import { AbstractBuff } from "../gamecharacters/buffs/AbstractBuff";
 import { Lethality } from "../gamecharacters/buffs/standard/Lethality";
 import { Stress } from "../gamecharacters/buffs/standard/Stress";
+import { GreedIncarnate } from "../gamecharacters/buffs/enemy_buffs/GreedIncarnate";
 import { CardResourceScaling } from "../gamecharacters/CardResourceScaling";
 import { IBaseCharacter } from "../gamecharacters/IBaseCharacter";
 import { PlayableCard } from "../gamecharacters/PlayableCard";
@@ -61,14 +62,45 @@ export class ActionManager {
     }
     modifySovereignInfernalNotes(amount: number) {
         this.actionQueue.addAction(new GenericAction(async () => {
-            GameState.getInstance().sovereignInfernalNotes += amount;
+            let amt = amount;
+            const combat = GameState.getInstance().combatState;
+            if (amt > 0 && combat) {
+                let greed: GreedIncarnate | undefined = undefined;
+                for (const enemy of combat.enemies) {
+                    const g = enemy.buffs.find(b => b instanceof GreedIncarnate) as GreedIncarnate | undefined;
+                    if (g) { greed = g; break; }
+                }
+                if (greed) {
+                    amt = greed.stealCurrency(amt);
+                }
+            }
+            GameState.getInstance().sovereignInfernalNotes += amt;
             return [];
         }));
     }
 
     modifyPromissoryNotes(amount: number) {
         this.actionQueue.addAction(new GenericAction(async () => {
-            GameState.getInstance().britishPoundsSterling += amount;
+            let amt = amount;
+            const combat = GameState.getInstance().combatState;
+            if (amt > 0 && combat) {
+                let greed: GreedIncarnate | undefined = undefined;
+                for (const enemy of combat.enemies) {
+                    const g = enemy.buffs.find(b => b instanceof GreedIncarnate) as GreedIncarnate | undefined;
+                    if (g) { greed = g; break; }
+                }
+                if (greed) {
+                    amt = greed.stealCurrency(amt);
+                }
+            }
+            GameState.getInstance().britishPoundsSterling += amt;
+            return [];
+        }));
+    }
+
+    modifyObols(amount: number) {
+        this.actionQueue.addAction(new GenericAction(async () => {
+            GameState.getInstance().obols += amount;
             return [];
         }));
     }


### PR DESCRIPTION
## Summary
- implement new buff Greed Incarnate
- implement new buff Harbinger of Fate
- add bosses Bloated Treasurer, Hermit Prophet of the Delta, and Hermit's Treasure
- track Obols in game state and modify currency actions
- include new bosses in Act 1 boss encounter list

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'phaser' and other existing errors)*