### PR TITLE
Add Marshal Mortis and Frost Chancellor bosses

### DIFF
--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -35,6 +35,8 @@ import { RunoffElemental } from './monsters/act1_segment2/RunoffElemental';
 import { TollCollectorGoneMad } from './monsters/act1_segment2/TollCollectorGoneMad';
 import { WoodGolem } from './monsters/act1_segment2/WoodGolem';
 import { LuridAutarch } from './monsters/act2_boss/LuridAutarch';
+import { MarshalMortis } from './monsters/act2_boss/MarshalMortis';
+import { TheFrostChancellor } from './monsters/act2_boss/TheFrostChancellor';
 import { BureaucraticBehemoth } from './monsters/act2_segment1/BureaucraticBehemoth';
 import { CrawlingInfestation } from './monsters/act2_segment1/CrawlingInfestation';
 import { FrenchPoliceman } from './monsters/act2_segment1/FrenchPoliceman';
@@ -225,6 +227,12 @@ export class ActSegment {
     static readonly Boss_Act2 = new ActSegmentData("Boss Fight - Act 2", 2, 3, [
         {
             enemies: [new LuridAutarch()]
+        },
+        {
+            enemies: [new MarshalMortis()]
+        },
+        {
+            enemies: [new TheFrostChancellor()]
         }
     ]);
 }

--- a/src/encounters/monsters/act2_boss/MarshalMortis.ts
+++ b/src/encounters/monsters/act2_boss/MarshalMortis.ts
@@ -1,0 +1,41 @@
+import { AbstractIntent, AttackAllPlayerCharactersIntent, ApplyBuffToAllEnemyCharactersIntent, ApplyDebuffToAllPlayerCharactersIntent, IntentListCreator, SummonIntent } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { GrandArmeeEternal } from '../../../gamecharacters/buffs/enemy_buffs/GrandArmeeEternal';
+import { Decaying } from '../../../gamecharacters/buffs/enemy_buffs/Decaying';
+import { Lethality } from '../../../gamecharacters/buffs/standard/Lethality';
+import { Vulnerable } from '../../../gamecharacters/buffs/standard/Vulnerable';
+import { OldGuardGrenadier } from '../act2_segment1/OldGuardGrenadier';
+import { CardSize } from '../../../gamecharacters/Primitives';
+
+export class MarshalMortis extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Marshal Mortis',
+            portraitName: 'Napoleonic Zombie',
+            maxHitpoints: 280,
+            description: 'undying master of the imperial legions'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new GrandArmeeEternal());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const g1 = new OldGuardGrenadier(); g1.maxHitpoints = 40; g1.hitpoints = 40;
+        const g2 = new OldGuardGrenadier(); g2.maxHitpoints = 40; g2.hitpoints = 40;
+        const intents: AbstractIntent[][] = [
+            [
+                new SummonIntent({ monsterToSummon: g1, owner: this }).withTitle('Send In The Next Wave'),
+                new SummonIntent({ monsterToSummon: g2, owner: this }).withTitle('Send In The Next Wave')
+            ],
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 15, owner: this }).withTitle('Artillery Barrage'),
+                new ApplyDebuffToAllPlayerCharactersIntent({ debuff: new Vulnerable(1), owner: this }).withTitle('Artillery Barrage')
+            ],
+            [
+                new ApplyBuffToAllEnemyCharactersIntent({ debuff: new Lethality(4), owner: this }).withTitle("Vive L'Empereur"),
+                new ApplyBuffToAllEnemyCharactersIntent({ debuff: new Decaying(1), owner: this }).withTitle("Vive L'Empereur")
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act2_boss/TheFrostChancellor.ts
+++ b/src/encounters/monsters/act2_boss/TheFrostChancellor.ts
@@ -1,0 +1,40 @@
+import { AbstractIntent, AddCardToPileIntent, ApplyBuffToSelfIntent, ApplyDebuffToAllPlayerCharactersIntent, AttackIntent, BlockForSelfIntent, IntentListCreator } from '../../../gamecharacters/AbstractIntent';
+import { AutomatedCharacter } from '../../../gamecharacters/AutomatedCharacter';
+import { AbsoluteZeroDoctrine } from '../../../gamecharacters/buffs/enemy_buffs/AbsoluteZeroDoctrine';
+import { Frostbite } from '../../../gamecharacters/buffs/standard/Frostbite';
+import { Lethality } from '../../../gamecharacters/buffs/standard/Lethality';
+import { Armored } from '../../../gamecharacters/buffs/standard/Armored';
+import { LoomingBlizzard } from '../../playerclasses/cards/other/tokens/LoomingBlizzard';
+import { CardSize } from '../../../gamecharacters/Primitives';
+
+export class TheFrostChancellor extends AutomatedCharacter {
+    constructor() {
+        super({
+            name: 'Frost Chancellor',
+            portraitName: 'frost_knight',
+            maxHitpoints: 250,
+            description: 'brings icy death to the unprepared'
+        });
+        this.size = CardSize.LARGE;
+        this.buffs.push(new Armored(5));
+        this.buffs.push(new AbsoluteZeroDoctrine());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AddCardToPileIntent({ cardToAdd: new LoomingBlizzard(), pileName: 'hand', owner: this }).withTitle('Commadore Snow')
+            ],
+            [
+                new ApplyDebuffToAllPlayerCharactersIntent({ debuff: new Frostbite(1), owner: this }).withTitle('Ice Age Protocol'),
+                new BlockForSelfIntent({ blockAmount: 20, owner: this }).withTitle('Ice Age Protocol'),
+                new ApplyBuffToSelfIntent({ buff: new Lethality(5), owner: this }).withTitle('Ice Age Protocol')
+            ],
+            [
+                new AttackIntent({ baseDamage: 15, owner: this }).withTitle('Shatter'),
+                new AttackIntent({ baseDamage: 15, owner: this }).withTitle('Shatter')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/AbsoluteZeroDoctrine.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/AbsoluteZeroDoctrine.ts
@@ -1,0 +1,33 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { GameState } from "../../../rules/GameState";
+import { Frostbite } from "../standard/Frostbite";
+import { WarmYourself } from "../../playerclasses/cards/other/tokens/WarmYourself";
+import { ActionManager } from "../../../utils/ActionManager";
+
+export class AbsoluteZeroDoctrine extends AbstractBuff {
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "snowflake";
+    }
+
+    override getDisplayName(): string { return "Absolute Zero Doctrine"; }
+    override getDescription(): string {
+        return "At the start of each turn, the hero with the most HP gains Frostbite and you gain a Warm Yourself.";
+    }
+
+    override onTurnStart(): void {
+        const gameState = GameState.getInstance();
+        const players = gameState.combatState.playerCharacters.filter(p => p.hitpoints > 0);
+        if (players.length > 0) {
+            let target = players[0];
+            for (const p of players) {
+                if (p.hitpoints > target.hitpoints) {
+                    target = p;
+                }
+            }
+            ActionManager.getInstance().applyBuffToCharacter(target, new Frostbite(1));
+        }
+        ActionManager.getInstance().createCardToHand(new WarmYourself());
+    }
+}

--- a/src/gamecharacters/buffs/enemy_buffs/GrandArmeeEternal.ts
+++ b/src/gamecharacters/buffs/enemy_buffs/GrandArmeeEternal.ts
@@ -1,0 +1,26 @@
+import { AbstractCombatEvent } from "../../../rules/AbstractCombatEvent";
+import { CharacterDeathEvent } from "../../../utils/actions/CombatEvents";
+import { AbstractBuff } from "../AbstractBuff";
+import { Lethality } from "../standard/Lethality";
+
+export class GrandArmeeEternal extends AbstractBuff {
+    constructor() {
+        super();
+        this.isDebuff = false;
+        this.imageName = "spear";
+    }
+
+    override getDisplayName(): string { return "Grand Armée Eternal"; }
+    override getDescription(): string {
+        return "When an ally dies, this character gains Lethality (2).";
+    }
+
+    override onEvent(event: AbstractCombatEvent): void {
+        if (event instanceof CharacterDeathEvent) {
+            const owner = this.getOwnerAsCharacter();
+            if (owner && event.deadCharacter.team === owner.team && event.deadCharacter !== owner) {
+                this.actionManager.applyBuffToCharacter(owner, new Lethality(2));
+            }
+        }
+    }
+}

--- a/src/gamecharacters/buffs/standard/Frostbite.ts
+++ b/src/gamecharacters/buffs/standard/Frostbite.ts
@@ -1,0 +1,41 @@
+import { BaseCharacter } from "../../BaseCharacter";
+import { PlayableCard } from "../../PlayableCard";
+import { AbstractBuff } from "../AbstractBuff";
+
+export class Frostbite extends AbstractBuff {
+    constructor(stacks: number = 1) {
+        super();
+        this.stacks = stacks;
+        this.isDebuff = true;
+        this.stackable = true;
+        this.imageName = "snowflake";
+        this.secondaryStacks = 0;
+    }
+
+    override getDisplayName(): string { return "Frostbite"; }
+    override getDescription(): string {
+        return `Lose 1 Dexterity and 1 Lethality. Playing two cards removes Frostbite.`;
+    }
+
+    override getBlockSentModifier(_target?: BaseCharacter): number {
+        return -1 * this.stacks;
+    }
+
+    override getCombatDamageDealtModifier(_target?: BaseCharacter, _sourceCard?: PlayableCard): number {
+        return -1 * this.stacks;
+    }
+
+    override onTurnStart(): void {
+        this.secondaryStacks = 0;
+    }
+
+    override onAnyCardPlayedByAnyone(card: PlayableCard): void {
+        const owner = this.getOwnerAsCharacter();
+        if (owner && card.owningCharacter === owner) {
+            this.secondaryStacks++;
+            if (this.secondaryStacks >= 2) {
+                this.actionManager.removeBuffFromCharacter(owner, this.getDisplayName());
+            }
+        }
+    }
+}

--- a/src/gamecharacters/playerclasses/cards/other/tokens/LoomingBlizzard.ts
+++ b/src/gamecharacters/playerclasses/cards/other/tokens/LoomingBlizzard.ts
@@ -1,0 +1,53 @@
+import { TargetingType } from "../../../../AbstractCard";
+import { BaseCharacter } from "../../../../BaseCharacter";
+import { EntityRarity } from "../../../../EntityRarity";
+import { PlayableCard } from "../../../../PlayableCard";
+import { CardType } from "../../../../Primitives";
+import { AbstractBuff } from "../../../../buffs/AbstractBuff";
+import { Frostbite } from "../../../../buffs/standard/Frostbite";
+import { GameState } from "../../../../rules/GameState";
+import { ActionManager } from "../../../../utils/ActionManager";
+
+class LoomingBlizzardBuff extends AbstractBuff {
+    override getDisplayName(): string { return "Looming Blizzard"; }
+    override getDescription(): string {
+        return "Unplayable. Ethereal. At end of turn, all characters with Frostbite take 15 damage.";
+    }
+
+    override onInHandAtEndOfTurn(): void {
+        const ownerCard = this.getOwnerAsPlayableCard();
+        if (ownerCard) {
+            const allChars = [
+                ...GameState.getInstance().combatState.playerCharacters,
+                ...GameState.getInstance().combatState.enemies,
+            ];
+            allChars.forEach(c => {
+                if (c.buffs.some(b => b instanceof Frostbite)) {
+                    ActionManager.getInstance().dealDamage({ baseDamageAmount: 15, target: c, fromAttack: false, sourceCard: ownerCard });
+                }
+            });
+            ActionManager.getInstance().exhaustCard(ownerCard);
+        }
+    }
+}
+
+export class LoomingBlizzard extends PlayableCard {
+    constructor() {
+        super({
+            name: "Looming Blizzard",
+            cardType: CardType.NON_PLAYABLE,
+            targetingType: TargetingType.NO_TARGETING,
+            rarity: EntityRarity.SPECIAL,
+        });
+        this.baseEnergyCost = 0;
+        this.buffs.push(new LoomingBlizzardBuff());
+    }
+
+    override get description(): string {
+        return "Unplayable. Ethereal. At end of turn, all characters with Frostbite take 15 damage.";
+    }
+
+    override InvokeCardEffects(_target?: BaseCharacter): void { }
+
+    override isUnplayable(): boolean { return true; }
+}

--- a/src/gamecharacters/playerclasses/cards/other/tokens/WarmYourself.ts
+++ b/src/gamecharacters/playerclasses/cards/other/tokens/WarmYourself.ts
@@ -1,0 +1,32 @@
+import { TargetingType } from "../../../../AbstractCard";
+import { BaseCharacter } from "../../../../BaseCharacter";
+import { ExhaustBuff } from "../../../../buffs/playable_card/ExhaustBuff";
+import { Transient } from "../../../../buffs/playable_card/Transient";
+import { EntityRarity } from "../../../../EntityRarity";
+import { PlayableCard } from "../../../../PlayableCard";
+import { CardType } from "../../../../Primitives";
+
+export class WarmYourself extends PlayableCard {
+    constructor() {
+        super({
+            name: "Warm Yourself",
+            cardType: CardType.SKILL,
+            targetingType: TargetingType.NO_TARGETING,
+            rarity: EntityRarity.COMMON,
+        });
+        this.baseEnergyCost = 2;
+        this.buffs.push(new ExhaustBuff());
+        this.buffs.push(new Transient());
+    }
+
+    override get description(): string {
+        return "Remove all Frostbite from yourself. Exhaust.";
+    }
+
+    override InvokeCardEffects(_target?: BaseCharacter): void {
+        const owner = this.owningCharacter;
+        if (owner) {
+            this.actionManager.removeBuffFromCharacter(owner, "Frostbite");
+        }
+    }
+}

--- a/src/rules/CombatRulesHelper.ts
+++ b/src/rules/CombatRulesHelper.ts
@@ -1,5 +1,7 @@
 import { IBaseCharacter } from "../gamecharacters/IBaseCharacter";
 import { GameState } from "./GameState";
+import { ProcBroadcaster } from "../gamecharacters/procs/ProcBroadcaster";
+import { CharacterDeathEvent } from "../utils/actions/CombatEvents";
 
 
 import { AutomatedCharacterType, BaseCharacterType, PlayableCardType } from "../Types";
@@ -54,6 +56,8 @@ export class CombatRules {
         combatState.currentHand = removeDeadCharacterCards(combatState.currentHand );
         combatState.currentDiscardPile = removeDeadCharacterCards(combatState.currentDiscardPile );
         combatState.drawPile = removeDeadCharacterCards(combatState.drawPile );
+
+        ProcBroadcaster.getInstance().broadcastCombatEvent(new CharacterDeathEvent(character as BaseCharacterType, killer as BaseCharacterType | null));
     }
 
 

--- a/src/utils/actions/CombatEvents.ts
+++ b/src/utils/actions/CombatEvents.ts
@@ -1,4 +1,5 @@
 import { PlayableCard } from "../../gamecharacters/PlayableCard";
+import { BaseCharacter } from "../../gamecharacters/BaseCharacter";
 import { AbstractCombatEvent } from "../../rules/AbstractCombatEvent";
 import { AbstractCombatResource } from "../../rules/combatresources/AbstractCombatResource";
 
@@ -22,3 +23,12 @@ export class ExhaustEvent extends AbstractCombatEvent {
         super();
     }
 } 
+export class CharacterDeathEvent extends AbstractCombatEvent {
+    constructor(public deadCharacter: BaseCharacter, public killer: BaseCharacter | null) {
+        super();
+    }
+
+    printJson(): void {
+        console.log(`{"event": "CharacterDeathEvent", "dead": "${this.deadCharacter.name}", "killer": "${this.killer?.name ?? ''}"}`);
+    }
+}


### PR DESCRIPTION
## Summary
- add new Frostbite debuff and supporting buffs
- implement Marshal Mortis and The Frost Chancellor act 2 bosses
- create token cards Looming Blizzard and Warm Yourself
- broadcast CharacterDeathEvent and hook Grand Armée Eternal buff
- register new bosses in EncounterManager
- tweak Warm Yourself to cost 2 and make it Transient

## Testing
- `npm run build` *(fails: webpack not found)*
- `npx tsc -p tsconfig.json` *(fails: missing phaser type definitions)*
