### PR TITLE
Add act 3 enemies and related buffs

### DIFF
--- a/src/encounters/monsters/act3_segment1/CompanyOverseer.ts
+++ b/src/encounters/monsters/act3_segment1/CompanyOverseer.ts
@@ -1,0 +1,31 @@
+import { AbstractIntent, AttackIntent, BlockForSelfIntent, IntentListCreator, SummonIntent } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { Bulwark } from "../../../gamecharacters/buffs/standard/Bulwark";
+import { Exploitation } from "../../../gamecharacters/buffs/standard/Exploitation";
+import { Bloodsucker } from "../../../gamecharacters/buffs/standard/Bloodsucker";
+import { MechanicalScab } from "./MechanicalScab";
+
+export class CompanyOverseer extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Company Overseer',
+            portraitName: 'overseer',
+            maxHitpoints: 70,
+            description: 'A ruthless manager of hellish industry.'
+        });
+        this.buffs.push(new Bulwark(2));
+        this.buffs.push(new Exploitation(2));
+        this.buffs.push(new Bloodsucker(3));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [ new SummonIntent({ monsterToSummon: new MechanicalScab(), owner: this }).withTitle('Efficiency Expert') ],
+            [
+                new BlockForSelfIntent({ blockAmount: 12, owner: this }).withTitle('Crackdown'),
+                new AttackIntent({ baseDamage: 20, owner: this })
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act3_segment1/FurnaceForeman.ts
+++ b/src/encounters/monsters/act3_segment1/FurnaceForeman.ts
@@ -1,0 +1,40 @@
+import { AbstractIntent, ApplyDebuffToAllPlayerCharactersIntent, ApplyDebuffToRandomCharacterIntent, AttackAllPlayerCharactersIntent, AttackIntent, IntentListCreator, SummonIntent } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { Armored } from "../../../gamecharacters/buffs/standard/Armored";
+import { Burning } from "../../../gamecharacters/buffs/standard/Burning";
+import { Vulnerable } from "../../../gamecharacters/buffs/standard/Vulnerable";
+import { Exploitation } from "../../../gamecharacters/buffs/standard/Exploitation";
+import { Bloodsucker } from "../../../gamecharacters/buffs/standard/Bloodsucker";
+import { MechanicalScab } from "./MechanicalScab";
+
+export class FurnaceForeman extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Furnace Foreman',
+            portraitName: 'foreman',
+            maxHitpoints: 80,
+            description: 'Master of the blistering forges.'
+        });
+        this.buffs.push(new Armored(2));
+        this.buffs.push(new Exploitation(2));
+        this.buffs.push(new Bloodsucker(3));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackAllPlayerCharactersIntent({ baseDamage: 6, owner: this }).withTitle('Bellows Blast'),
+                new ApplyDebuffToAllPlayerCharactersIntent({ debuff: new Burning(1), owner: this })
+            ],
+            [
+                new AttackIntent({ baseDamage: 14, owner: this }).withTitle('Molten Pour'),
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Vulnerable(2), owner: this })
+            ],
+            [
+                new AttackIntent({ baseDamage: 10, owner: this }).withTitle('Strikebreaker'),
+                new SummonIntent({ monsterToSummon: new MechanicalScab(), owner: this })
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act3_segment1/MechanicalScab.ts
+++ b/src/encounters/monsters/act3_segment1/MechanicalScab.ts
@@ -1,0 +1,19 @@
+import { AbstractIntent, AttackIntent } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { GrowingPowerBuff } from "../../../gamecharacters/buffs/standard/GrowingPower";
+
+export class MechanicalScab extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Mechanical Scab',
+            portraitName: 'robot-minion',
+            maxHitpoints: 15,
+            description: 'A crude automaton patched together from scrap.'
+        });
+        this.buffs.push(new GrowingPowerBuff(2));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        return [ new AttackIntent({ baseDamage: 5, owner: this }) ];
+    }
+}

--- a/src/encounters/monsters/act3_segment1/MoltenAgitator.ts
+++ b/src/encounters/monsters/act3_segment1/MoltenAgitator.ts
@@ -1,0 +1,48 @@
+import { AbstractIntent, ApplyBuffToAllEnemyCharactersIntent, ApplyDebuffToAllPlayerCharactersIntent, ApplyDebuffToRandomCharacterIntent, AttackIntent, DoSomethingIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { Burning } from "../../../gamecharacters/buffs/standard/Burning";
+import { Lethality } from "../../../gamecharacters/buffs/standard/Lethality";
+import { RevolutionaryFervor } from "../../../gamecharacters/buffs/standard/RevolutionaryFervor";
+import { BurningImmune } from "../../../gamecharacters/buffs/standard/BurningImmune";
+import { TargetingUtils } from "../../../utils/TargetingUtils";
+
+export class MoltenAgitator extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Molten Agitator',
+            portraitName: 'fiery-orator',
+            maxHitpoints: 50,
+            description: 'A fanatic spouting incendiary rhetoric.'
+        });
+        this.buffs.push(new RevolutionaryFervor(4));
+        this.buffs.push(new BurningImmune());
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new DoSomethingIntent({
+                    owner: this,
+                    imageName: 'fire-breath',
+                    action: () => {
+                        for (const ally of TargetingUtils.getInstance().selectAllEnemyCharacters()) {
+                            this.actionManager.applyBuffToCharacter(ally, new Lethality(2));
+                        }
+                        const everyone = [...TargetingUtils.getInstance().selectAllEnemyCharacters(), ...TargetingUtils.getInstance().selectAllPlayerCharacters()];
+                        for (const c of everyone) {
+                            this.actionManager.applyBuffToCharacter(c, new Burning(3));
+                        }
+                    }
+                }).withTitle('Inflammatory Speech')
+            ],
+            [
+                new AttackIntent({ baseDamage: 10, owner: this }).withTitle('Thrown Slag'),
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Burning(2), owner: this })
+            ],
+            [
+                new AttackIntent({ baseDamage: 15, owner: this }).withTitle('Boiling Blood')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act3_segment1/UnionEnforcer.ts
+++ b/src/encounters/monsters/act3_segment1/UnionEnforcer.ts
@@ -1,0 +1,39 @@
+import { AbstractIntent, ApplyDebuffToRandomCharacterIntent, AttackIntent, DoSomethingIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { Armored } from "../../../gamecharacters/buffs/standard/Armored";
+import { Lumbering } from "../../../gamecharacters/buffs/enemy_buffs/Lumbering";
+import { RevolutionaryFervor } from "../../../gamecharacters/buffs/standard/RevolutionaryFervor";
+import { Weak } from "../../../gamecharacters/buffs/standard/Weak";
+import { Stress } from "../../../gamecharacters/buffs/standard/Stress";
+import { StunnedBuff } from "../../../gamecharacters/buffs/playable_card/Stunned";
+
+export class UnionEnforcer extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Union Enforcer',
+            portraitName: 'tough-worker',
+            maxHitpoints: 165,
+            description: 'Heavy muscle for the cause.'
+        });
+        this.buffs.push(new RevolutionaryFervor(9));
+        this.buffs.push(new Armored(3));
+        this.buffs.push(new Lumbering(1));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackIntent({ baseDamage: 12, owner: this }).withTitle('Knuckle Duster'),
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new StunnedBuff(1), owner: this })
+            ],
+            [
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Stress(2), owner: this }).withTitle('Intimidate'),
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Weak(2), owner: this })
+            ],
+            [
+                new AttackIntent({ baseDamage: 18, owner: this }).withTitle("Workers' Justice")
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/encounters/monsters/act3_segment1/WildcatStriker.ts
+++ b/src/encounters/monsters/act3_segment1/WildcatStriker.ts
@@ -1,0 +1,49 @@
+import { AbstractIntent, AddCardToPileIntent, ApplyDebuffToRandomCharacterIntent, AttackIntent, DoSomethingIntent, IntentListCreator } from "../../../gamecharacters/AbstractIntent";
+import { AutomatedCharacter } from "../../../gamecharacters/AutomatedCharacter";
+import { Weak } from "../../../gamecharacters/buffs/standard/Weak";
+import { Vulnerable } from "../../../gamecharacters/buffs/standard/Vulnerable";
+import { Lethality } from "../../../gamecharacters/buffs/standard/Lethality";
+import { RevolutionaryFervor } from "../../../gamecharacters/buffs/standard/RevolutionaryFervor";
+import { Terrifying } from "../../../gamecharacters/buffs/standard/Terrifying";
+import { BrokenGear } from "../../../gamecharacters/statuses/BrokenGear";
+import { TargetingUtils } from "../../../utils/TargetingUtils";
+
+export class WildcatStriker extends AutomatedCharacter {
+    constructor(){
+        super({
+            name: 'Wildcat Striker',
+            portraitName: 'angry-worker',
+            maxHitpoints: 45,
+            description: 'An enraged union militant.'
+        });
+        this.buffs.push(new RevolutionaryFervor(5));
+        this.buffs.push(new Terrifying(1));
+    }
+
+    override generateNewIntents(): AbstractIntent[] {
+        const intents: AbstractIntent[][] = [
+            [
+                new AttackIntent({ baseDamage: 8, owner: this }).withTitle('Picket Line'),
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Weak(1), owner: this })
+            ],
+            [
+                new ApplyDebuffToRandomCharacterIntent({ debuff: new Vulnerable(2), owner: this }).withTitle('Sabotage'),
+                new AddCardToPileIntent({ cardToAdd: new BrokenGear(), pileName: 'draw', owner: this }),
+                new AddCardToPileIntent({ cardToAdd: new BrokenGear(), pileName: 'draw', owner: this })
+            ],
+            [
+                new DoSomethingIntent({
+                    owner: this,
+                    imageName: 'round-shield',
+                    action: () => {
+                        for (const enemy of TargetingUtils.getInstance().selectAllEnemyCharacters()) {
+                            this.actionManager.applyBlock({ baseBlockValue: 8, blockSourceCharacter: this, blockTargetCharacter: enemy });
+                            this.actionManager.applyBuffToCharacter(enemy, new Lethality(3));
+                        }
+                    }
+                }).withTitle('Solidarity Forever')
+            ]
+        ];
+        return IntentListCreator.iterateIntents(intents);
+    }
+}

--- a/src/gamecharacters/buffs/standard/Bloodsucker.ts
+++ b/src/gamecharacters/buffs/standard/Bloodsucker.ts
@@ -1,0 +1,29 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { ResourceUsedEvent } from "../../../rules/combatresources/AbstractCombatResource";
+import { Regeneration } from "../enemy_buffs/Regeneration";
+
+export class Bloodsucker extends AbstractBuff {
+    constructor(stacks: number = 1){
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "blood";
+    }
+
+    override getDisplayName(): string {
+        return "Bloodsucker";
+    }
+
+    override getDescription(): string {
+        return `Whenever you gain Blood, this character receives +${this.getStacksDisplayText()} Regeneration.`;
+    }
+
+    override onEvent(event: ResourceUsedEvent): void {
+        if (event instanceof ResourceUsedEvent && event.isBlood()) {
+            const owner = this.getOwnerAsCharacter();
+            if (owner) {
+                this.actionManager.applyBuffToCharacter(owner, new Regeneration(this.stacks));
+            }
+        }
+    }
+}

--- a/src/gamecharacters/buffs/standard/BurningImmune.ts
+++ b/src/gamecharacters/buffs/standard/BurningImmune.ts
@@ -1,0 +1,22 @@
+import { AbstractBuff, BuffApplicationResult } from "../AbstractBuff";
+import { AbstractBuff as Buff } from "../AbstractBuff";
+import { Burning } from "./Burning";
+
+export class BurningImmune extends AbstractBuff {
+    constructor(){
+        super();
+        this.isDebuff = false;
+        this.imageName = "flame-off";
+    }
+
+    override getDisplayName(): string { return "Burning Immune"; }
+
+    override getDescription(): string { return "Immune to Burning."; }
+
+    override interceptBuffApplication(_character: Buff, buffApplied: Buff, _previous: number, change: number): BuffApplicationResult {
+        if (buffApplied instanceof Burning && change > 0) {
+            return { logicTriggered: true, newChangeInStacks: 0 };
+        }
+        return { logicTriggered: false, newChangeInStacks: change };
+    }
+}

--- a/src/gamecharacters/buffs/standard/Exploitation.ts
+++ b/src/gamecharacters/buffs/standard/Exploitation.ts
@@ -1,0 +1,29 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { ResourceUsedEvent } from "../../../rules/combatresources/AbstractCombatResource";
+import { Lethality } from "./Lethality";
+
+export class Exploitation extends AbstractBuff {
+    constructor(stacks: number = 1){
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "greedy";
+    }
+
+    override getDisplayName(): string {
+        return "Exploitation";
+    }
+
+    override getDescription(): string {
+        return `Whenever you gain Venture, this character receives +${this.getStacksDisplayText()} Lethality.`;
+    }
+
+    override onEvent(event: ResourceUsedEvent): void {
+        if (event instanceof ResourceUsedEvent && event.isVenture()) {
+            const owner = this.getOwnerAsCharacter();
+            if (owner) {
+                this.actionManager.applyBuffToCharacter(owner, new Lethality(this.stacks));
+            }
+        }
+    }
+}

--- a/src/gamecharacters/buffs/standard/RevolutionaryFervor.ts
+++ b/src/gamecharacters/buffs/standard/RevolutionaryFervor.ts
@@ -1,0 +1,30 @@
+import { AbstractBuff } from "../AbstractBuff";
+import { AbstractCombatEvent } from "../../../rules/AbstractCombatEvent";
+import { CharacterDeathEvent } from "../../../utils/actions/CombatEvents";
+import { Lethality } from "./Lethality";
+
+export class RevolutionaryFervor extends AbstractBuff {
+    constructor(stacks: number = 1){
+        super();
+        this.stacks = stacks;
+        this.isDebuff = false;
+        this.imageName = "fist";
+    }
+
+    override getDisplayName(): string {
+        return "Revolutionary Fervor";
+    }
+
+    override getDescription(): string {
+        return `Whenever an ally dies, gain +${this.getStacksDisplayText()} Lethality.`;
+    }
+
+    override onEvent(event: AbstractCombatEvent): void {
+        if (event instanceof CharacterDeathEvent){
+            const owner = this.getOwnerAsCharacter();
+            if (owner && event.deadCharacter.team === owner.team && event.deadCharacter !== owner){
+                this.actionManager.applyBuffToCharacter(owner, new Lethality(this.stacks));
+            }
+        }
+    }
+}

--- a/src/gamecharacters/statuses/BrokenGear.ts
+++ b/src/gamecharacters/statuses/BrokenGear.ts
@@ -1,0 +1,26 @@
+import { TargetingType } from "../AbstractCard";
+import { EntityRarity } from "../EntityRarity";
+import { PlayableCard } from "../PlayableCard";
+import { CardType } from "../Primitives";
+import { Heavy } from "../buffs/playable_card/Heavy";
+import { Hazardous } from "../buffs/playable_card/Hazardous";
+
+export class BrokenGear extends PlayableCard {
+    constructor(){
+        super({
+            name: "Broken Gear",
+            cardType: CardType.STATUS,
+            targetingType: TargetingType.NO_TARGETING,
+            rarity: EntityRarity.SPECIAL,
+        });
+        this.baseEnergyCost = 0;
+        this.buffs.push(new Heavy());
+        this.buffs.push(new Hazardous(2));
+    }
+
+    override get description(): string {
+        return "Clutters your deck.";
+    }
+
+    override InvokeCardEffects(): void {}
+}


### PR DESCRIPTION
## Summary
- implement new buffs: Exploitation, Bloodsucker, Revolutionary Fervor and Burning Immune
- add Broken Gear status card
- add Act 3 enemies (Wildcat Striker, Union Enforcer, Molten Agitator)
- add Brimstone Baron foes (Company Overseer, Furnace Foreman) and Mechanical Scab minion
- refactor Bloodsucker and Exploitation buffs to listen for ResourceUsedEvent instead of modifyCombatResourceGained

## Testing
- `npm run build` *(fails: webpack not found)*