### PR TITLE
Add event character slot mechanism

### DIFF
--- a/src/encounters/events/AngelicTattooEvent.ts
+++ b/src/encounters/events/AngelicTattooEvent.ts
@@ -19,7 +19,7 @@ class BasicTattooChoice extends AbstractChoice {
 
     effect(): void {
         const gameState = this.gameState();
-        const character = this.getRandomCharacter(); // Assumes first character is the soldier
+        const character = this.getEventCharacter(1); // predetermined soldier
         const actionManager = ActionManager.getInstance();
         
         // Apply angelic tattoo buff and stress
@@ -48,7 +48,7 @@ class ElaborateTattooChoice extends AbstractChoice {
 
     effect(): void {
         const gameState = this.gameState();
-        const character = this.getRandomCharacter();
+        const character = this.getEventCharacter(1);
         const actionManager = ActionManager.getInstance();
         
         // Apply more powerful angelic tattoo buff and stress

--- a/src/encounters/events/DiseaseForRewardEvent.ts
+++ b/src/encounters/events/DiseaseForRewardEvent.ts
@@ -43,7 +43,7 @@ class AcceptDiseaseChoice extends AbstractChoice {
 
     effect(): void {
         const gameState = this.gameState();
-        const character = this.getRandomCharacter(); 
+        const character = this.getEventCharacter(1);
         const actionManager = ActionManager.getInstance();
         
         // Apply random disease debuff

--- a/src/events/AbstractEvent.ts
+++ b/src/events/AbstractEvent.ts
@@ -39,6 +39,27 @@ export abstract class AbstractChoice {
         return characters[Math.floor(Math.random() * characters.length)];
     }
 
+    /**
+     * Retrieve the event character assigned in the parent event.
+     * Falls back to a random character if the slot is undefined.
+     */
+    protected getEventCharacter(slot: 1 | 2 | 3): BaseCharacter {
+        if (this.parentEvent) {
+            switch (slot) {
+                case 1:
+                    if (this.parentEvent.character_1) return this.parentEvent.character_1;
+                    break;
+                case 2:
+                    if (this.parentEvent.character_2) return this.parentEvent.character_2;
+                    break;
+                case 3:
+                    if (this.parentEvent.character_3) return this.parentEvent.character_3;
+                    break;
+            }
+        }
+        return this.getRandomCharacter();
+    }
+
 }
 export class FinishChoice extends AbstractChoice {
     constructor() {
@@ -61,6 +82,62 @@ export class AbstractEvent {
     public description: string = "";
     public choices: AbstractChoice[] = [new FinishChoice()];
     public parentEvent?: AbstractEvent;
+    // Characters selected for this event instance
+    public character_1?: BaseCharacter;
+    public character_2?: BaseCharacter;
+    public character_3?: BaseCharacter;
+    private initialized: boolean = false;
+
+    /**
+     * Called when the event is shown. Randomizes the character assignments so
+     * that choices can consistently reference them.
+     */
+    public init(): void {
+        if (this.initialized) {
+            return;
+        }
+
+        // If we have a parent event, inherit its characters so the chain is consistent
+        if (this.parentEvent) {
+            this.character_1 = this.parentEvent.character_1;
+            this.character_2 = this.parentEvent.character_2;
+            this.character_3 = this.parentEvent.character_3;
+            this.initialized = true;
+            return;
+        }
+
+        const characters = [...this.gameState().currentRunCharacters];
+        let available = [...characters];
+
+        const pull = (preferLiving: boolean): BaseCharacter => {
+            let pool = preferLiving
+                ? available.filter(c => !c.isDead())
+                : available;
+
+            if (pool.length === 0) {
+                pool = available;
+            }
+
+            if (pool.length === 0) {
+                // As a last resort fall back to the full character list
+                pool = characters;
+            }
+
+            const idx = Math.floor(Math.random() * pool.length);
+            const char = pool[idx];
+            const removeIdx = available.indexOf(char);
+            if (removeIdx !== -1) {
+                available.splice(removeIdx, 1);
+            }
+            return char;
+        };
+
+        this.character_1 = pull(true); // Avoid assigning dead characters if possible
+        this.character_2 = pull(true);
+        this.character_3 = pull(true);
+
+        this.initialized = true;
+    }
     public isEligible(): boolean {
         return true;
     }

--- a/src/screens/subcomponents/CombatUiManager.ts
+++ b/src/screens/subcomponents/CombatUiManager.ts
@@ -750,6 +750,10 @@ class CombatUIManager {
         if (this.eventWindow) {
             this.eventWindow.destroy();
         }
+        // Initialize the event so any random selections are ready for choices
+        if (event.init) {
+            event.init();
+        }
 
         this.eventWindow = new EventWindow(
             this.scene,


### PR DESCRIPTION
## Summary
- randomize `character_1`, `character_2`, `character_3` when an event is shown
- expose `getEventCharacter` for choices
- initialize events in `CombatUiManager.showEvent`
- update AngelicTattooEvent and DiseaseForRewardEvent to use the new event characters
- keep event characters consistent across entire chain and avoid dead characters

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'phaser')*