### PR TITLE
Add DeadEndStartEncounterChoice for combat chaining

### DIFF
--- a/src/encounters/EncounterManager.ts
+++ b/src/encounters/EncounterManager.ts
@@ -346,14 +346,27 @@ export class Encounter {
     segment: integer;
     enemies: AutomatedCharacter[];
     event?: AbstractEvent;
+    /**
+     * If true, the associated event should trigger after combat instead of
+     * immediately when the encounter begins.
+     */
+    eventAfterCombat: boolean = false;
     backgroundNameOverride?: string;
 
-    constructor(enemies: AutomatedCharacter[], act: integer, segment: integer, event?: AbstractEvent, backgroundNameOverride?: string) {
+    constructor(
+        enemies: AutomatedCharacter[],
+        act: integer,
+        segment: integer,
+        event?: AbstractEvent,
+        backgroundNameOverride?: string,
+        eventAfterCombat: boolean = false
+    ) {
         this.enemies = enemies;
         this.act = act;
         this.segment = segment;
         this.event = event;
         this.backgroundNameOverride = backgroundNameOverride;
+        this.eventAfterCombat = eventAfterCombat;
     }
 }
 

--- a/src/encounters/events/MarshBrigandsTollEvent.ts
+++ b/src/encounters/events/MarshBrigandsTollEvent.ts
@@ -1,14 +1,16 @@
 // Event: Marsh Brigands demanding toll
-import { AbstractChoice, AbstractEvent, DeadEndEvent } from "../../events/AbstractEvent";
+import { AbstractEvent, DeadEndEvent, DeadEndStartEncounterChoice } from "../../events/AbstractEvent";
 import { Encounter } from "../EncounterManager";
 import { Brigand } from "../monsters/act1_segment1/act1_segment0/Brigand";
 import { ActionManagerFetcher } from "../../utils/ActionManagerFetcher";
 import { AbstractConsumable } from "../../consumables/AbstractConsumable";
 
-class FightThroughChoice extends AbstractChoice {
+class FightThroughChoice extends DeadEndStartEncounterChoice {
     constructor() {
+        const dummyEncounter = new Encounter([], 0, 0);
         super(
             "Fight Through",
+            dummyEncounter,
             "Order the attack. You've faced worse odds. Probably."
         );
         this.nextEvent = new DeadEndEvent();
@@ -26,8 +28,10 @@ class FightThroughChoice extends AbstractChoice {
     }
 
     effect(): void {
-        const encounter = new Encounter([new Brigand(), new Brigand(), new Brigand()], this.gameState().currentAct, 0);
-        this.actionManager().cleanupAndRestartCombat({ encounter, shouldStartWithMapOverlay: false });
+        this.encounter.enemies = [new Brigand(), new Brigand(), new Brigand()];
+        this.encounter.act = this.gameState().currentAct;
+        this.encounter.segment = 0;
+        super.effect();
     }
 }
 


### PR DESCRIPTION
## Summary
- add `DeadEndStartEncounterChoice` that starts combat and chains to an event after victory
- support post-combat events via new `eventAfterCombat` flag on `Encounter`
- update combat scene logic to trigger such events after fights
- refactor DutchZooEscape and MarshBrigandsToll events to use the new choice type

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module 'phaser' etc.)*